### PR TITLE
Added names of registers to the simulator view

### DIFF
--- a/src/main/frontend/index.html
+++ b/src/main/frontend/index.html
@@ -70,166 +70,199 @@
             </colgroup>
             <thead>
               <th>ID</th>
+              <th>Name</th>
               <th>Value</th>
             </thead>
             <tbody id="register-listing-body">
               <tr id="reg-0">
                 <td id="reg-0-id">x0</td>
+                <td id="reg-0-name">zero</td>
                 <td id="reg-0-val">0</td>
               </tr>
 
               <tr id="reg-1">
                 <td id="reg-1-id">x1</td>
+                <td id="reg-1-name">ra</td>
                 <td id="reg-1-val">0</td>
               </tr>
 
               <tr id="reg-2">
                 <td id="reg-2-id">x2</td>
+                <td id="reg-2-name">sp</td>
                 <td id="reg-2-val">0</td>
               </tr>
 
               <tr id="reg-3">
                 <td id="reg-3-id">x3</td>
+                <td id="reg-3-name">gp</td>
                 <td id="reg-3-val">0</td>
               </tr>
 
               <tr id="reg-4">
                 <td id="reg-4-id">x4</td>
+                <td id="reg-4-name">tp</td>
                 <td id="reg-4-val">0</td>
               </tr>
 
               <tr id="reg-5">
                 <td id="reg-5-id">x5</td>
+                <td id="reg-5-name">t0</td>
                 <td id="reg-5-val">0</td>
               </tr>
 
               <tr id="reg-6">
                 <td id="reg-6-id">x6</td>
+                <td id="reg-6-name">t1</td>
                 <td id="reg-6-val">0</td>
               </tr>
 
               <tr id="reg-7">
                 <td id="reg-7-id">x7</td>
+                <td id="reg-7-name">t2</td>
                 <td id="reg-7-val">0</td>
               </tr>
 
               <tr id="reg-8">
                 <td id="reg-8-id">x8</td>
+                <td id="reg-8-name">s0/fp</td>
                 <td id="reg-8-val">0</td>
               </tr>
 
               <tr id="reg-9">
                 <td id="reg-9-id">x9</td>
+                <td id="reg-9-name">s1</td>
                 <td id="reg-9-val">0</td>
               </tr>
 
               <tr id="reg-10">
                 <td id="reg-10-id">x10</td>
+                <td id="reg-10-name">a0</td>
                 <td id="reg-10-val">0</td>
               </tr>
 
               <tr id="reg-11">
                 <td id="reg-11-id">x11</td>
+                <td id="reg-11-name">a1</td>
                 <td id="reg-11-val">0</td>
               </tr>
 
               <tr id="reg-12">
                 <td id="reg-12-id">x12</td>
+                <td id="reg-12-name">a2</td>
                 <td id="reg-12-val">0</td>
               </tr>
 
               <tr id="reg-13">
                 <td id="reg-13-id">x13</td>
+                <td id="reg-13-name">a3</td>
                 <td id="reg-13-val">0</td>
               </tr>
 
               <tr id="reg-14">
                 <td id="reg-14-id">x14</td>
+                <td id="reg-14-name">a4</td>
                 <td id="reg-14-val">0</td>
               </tr>
 
               <tr id="reg-15">
                 <td id="reg-15-id">x15</td>
+                <td id="reg-15-name">a5</td>
                 <td id="reg-15-val">0</td>
               </tr>
 
               <tr id="reg-16">
                 <td id="reg-16-id">x16</td>
+                <td id="reg-16-name">a6</td>
                 <td id="reg-16-val">0</td>
               </tr>
 
               <tr id="reg-17">
                 <td id="reg-17-id">x17</td>
+                <td id="reg-17-name">a7</td>
                 <td id="reg-17-val">0</td>
               </tr>
 
               <tr id="reg-18">
                 <td id="reg-18-id">x18</td>
+                <td id="reg-18-name">s2</td>
                 <td id="reg-18-val">0</td>
               </tr>
 
               <tr id="reg-19">
                 <td id="reg-19-id">x19</td>
+                <td id="reg-19-name">s3</td>
                 <td id="reg-19-val">0</td>
               </tr>
 
               <tr id="reg-20">
                 <td id="reg-20-id">x20</td>
+                <td id="reg-20-name">s4</td>
                 <td id="reg-20-val">0</td>
               </tr>
 
               <tr id="reg-21">
                 <td id="reg-21-id">x21</td>
+                <td id="reg-21-name">s5</td>
                 <td id="reg-21-val">0</td>
               </tr>
 
               <tr id="reg-22">
                 <td id="reg-22-id">x22</td>
+                <td id="reg-22-name">s6</td>
                 <td id="reg-22-val">0</td>
               </tr>
 
               <tr id="reg-23">
                 <td id="reg-23-id">x23</td>
+                <td id="reg-23-name">s7</td>
                 <td id="reg-23-val">0</td>
               </tr>
 
               <tr id="reg-24">
                 <td id="reg-24-id">x24</td>
+                <td id="reg-24-name">s8</td>
                 <td id="reg-24-val">0</td>
               </tr>
 
               <tr id="reg-25">
                 <td id="reg-25-id">x25</td>
+                <td id="reg-25-name">s9</td>
                 <td id="reg-25-val">0</td>
               </tr>
 
               <tr id="reg-26">
                 <td id="reg-26-id">x26</td>
+                <td id="reg-26-name">s10</td>
                 <td id="reg-26-val">0</td>
               </tr>
 
               <tr id="reg-27">
                 <td id="reg-27-id">x27</td>
+                <td id="reg-27-name">s11</td>
                 <td id="reg-27-val">0</td>
               </tr>
 
               <tr id="reg-28">
                 <td id="reg-28-id">x28</td>
+                <td id="reg-28-name">t3</td>
                 <td id="reg-28-val">0</td>
               </tr>
 
               <tr id="reg-29">
                 <td id="reg-29-id">x29</td>
+                <td id="reg-29-name">t4</td>
                 <td id="reg-29-val">0</td>
               </tr>
 
               <tr id="reg-30">
                 <td id="reg-30-id">x30</td>
+                <td id="reg-30-name">t5</td>
                 <td id="reg-30-val">0</td>
               </tr>
 
               <tr id="reg-31">
                 <td id="reg-31-id">x31</td>
+                <td id="reg-31-name">t6</td>
                 <td id="reg-31-val">0</td>
               </tr>
             </tbody>


### PR DESCRIPTION
As said above, should make reading the simulator easier as it will allow users to know which registers are which based on the names