### PR TITLE
Fix package names for JAL/LUI

### DIFF
--- a/src/main/kotlin/venus/riscv/insts/jal.kt
+++ b/src/main/kotlin/venus/riscv/insts/jal.kt
@@ -1,3 +1,5 @@
+package venus.riscv.insts
+
 import venus.riscv.InstructionField
 import venus.riscv.MachineCode
 import venus.riscv.insts.dsl.Instruction

--- a/src/main/kotlin/venus/riscv/insts/lui.kt
+++ b/src/main/kotlin/venus/riscv/insts/lui.kt
@@ -1,3 +1,5 @@
+package venus.riscv.insts
+
 import venus.riscv.InstructionField
 import venus.riscv.insts.dsl.UTypeInstruction
 


### PR DESCRIPTION
For some reason two files have no `package`. This PR makes things consistent with other instructions.