### PR TITLE
Support .align directive as power of 2

### DIFF
--- a/src/main/kotlin/venus/assembler/Assembler.kt
+++ b/src/main/kotlin/venus/assembler/Assembler.kt
@@ -186,7 +186,22 @@ internal class AssemblerPassOne(private val text: String) {
                 args.forEach(prog::makeLabelGlobal)
             }
 
-            ".float", ".double", ".align" -> {
+            ".align" -> {
+                checkArgsLength(args, 1)
+                val pow2 = userStringToInt(args[0])
+                if (pow2 < 0 || pow2 > 8) {
+                    throw AssemblerError(".align argument must be between 0 and 8, inclusive")
+                }
+                val mask = (1 shl pow2) - 1 // Sets pow2 rightmost bits to 1
+
+                /* Add padding until data offset aligns with given power of 2 */
+                while ((currentDataOffset and mask) != 0) {
+                    prog.addToData(0)
+                    currentDataOffset++
+                }
+            }
+
+            ".float", ".double" -> {
                 println("Warning: $directive not currently supported!")
             }
 

--- a/src/test/kotlin/assembler/AssemblerTest.kt
+++ b/src/test/kotlin/assembler/AssemblerTest.kt
@@ -58,4 +58,29 @@ class AssemblerTest {
         sim.step()
         assertEquals(0b10001, sim.getReg(9))
     }
+
+    @Test fun alignTest() {
+        val (prog, _) = Assembler.assemble("""
+        .data
+        .align 3
+        one: # 8-byte aligned
+        .byte 1
+        .align 3
+        two: # 8-byte aligned
+        .byte 2
+        .align 2
+        three: # 4-byte aligned
+        .byte 3
+        .text
+        la a1, one
+        la a2, two
+        la a3, three
+        sub x5, a2, a1  # Should be 8
+        sub x6, a3, a2  # Should be 4
+        """)
+        val sim = Simulator(Linker.link(listOf(prog)))
+        sim.run()
+        assertEquals(8, sim.getReg(5))
+        assertEquals(4, sim.getReg(6))
+    }
 }


### PR DESCRIPTION
This PR adds basic support for the .align X directive, which aligns data bytes to an offset that is a multiple of 2^X. This is a subset of the [features supported in the official toolchain](https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md). Custom padding bytes and padding limit is not yet supported.