### PR TITLE
Support .string as alias of .asciiz for portability

### DIFF
--- a/src/main/kotlin/venus/assembler/Assembler.kt
+++ b/src/main/kotlin/venus/assembler/Assembler.kt
@@ -151,7 +151,7 @@ internal class AssemblerPassOne(private val text: String) {
                 }
             }
 
-            ".asciiz" -> {
+            ".string", ".asciiz" -> {
                 checkArgsLength(args, 1)
                 val ascii: String = try {
                     JSON.parse(args[0])


### PR DESCRIPTION
Venus currently supports the `.asciiz` directive for emitting ASCII strings, which is non-standard (i.e., not supported by the [GNU-based toolchain](https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md)).

This PR adds an alias `.string` so that the same program can be executed under say both Venus and Spike.