### PR TITLE
DIVU by 0 should 0xFFFFFFFF instead of rs1

### DIFF
--- a/src/main/kotlin/venus/riscv/insts/divu.kt
+++ b/src/main/kotlin/venus/riscv/insts/divu.kt
@@ -10,7 +10,7 @@ val divu = RTypeInstruction(
         eval32 = { a, b ->
             val x = a.toLong() shl 32 ushr 32
             val y = b.toLong() shl 32 ushr 32
-            if (y == 0L) a
+            if (y == 0L) (-1).toInt()
             else (x / y).toInt()
         }
 )


### PR DESCRIPTION
DIVU by 0 currently returns the dividend, whereas the current spec (2.2) for the M extension specifies that all bits should be set in the result.